### PR TITLE
Fixed function call bug in client

### DIFF
--- a/2021sp_cs361s/network_classroom/src/network_classroom/spoke.py
+++ b/2021sp_cs361s/network_classroom/src/network_classroom/spoke.py
@@ -17,7 +17,7 @@ def user_to_ip(name):
         b += hash[10+i]
     ipaddr = "192.168.{}.{}".format(a%256, b%256)
     if ipaddr in _ip_to_user and _ip_to_user[ipaddr] != name:
-        return _user_to_ip("_"+name)
+        return user_to_ip("_"+name)
     _ip_to_user[ipaddr] = name
     _user_to_ip[name] = ipaddr
     return ipaddr


### PR DESCRIPTION
The recursive call to user_to_ip() was mistyped as _user_to_ip().

If there is a username collision, then clients will throw an error trying to make a function call to the dictionary named `_user_to_ip` instead of calling the function `user_to_ip()`.

The usernames "AzN" and "msx" will result in such a collision.