### PR TITLE
updated command in lab3 instructions for signing certificate

### DIFF
--- a/2021sp_cs361s/labs/lab3/lab3_instructions.md
+++ b/2021sp_cs361s/labs/lab3/lab3_instructions.md
@@ -269,7 +269,7 @@ prefer you didn't change it.
 
 To sign the certificate,
 
-    openssl x509 -req -days 360 -in lab2.csr -CA CS361S_Fall2020_CA.pem -CAkey CS361S_Spring2021_CA.key -CAcreateserial -out lab2.cert
+    openssl x509 -req -days 360 -in lab2.csr -CA CS361S_Spring2021_CA.pem -CAkey CS361S_Spring2021_CA.key -CAcreateserial -out lab2.cert
     
 This will spit out a signed certificate in the file `lab2.cert`. You will need this
 for the lab.


### PR DESCRIPTION
The command for signing the `cs361s.utexas.lab2` certificate is outdated, using the Fall2020 CA instead of the Spring2021 one (caused me a bit of head-scratching when I was trying to set up the lab lol)